### PR TITLE
Add a button to bring up can device.

### DIFF
--- a/app.py
+++ b/app.py
@@ -219,10 +219,16 @@ def api_modbus_client():
     return { 'status': 'Success', 'data': 'OK' }
 
 # CAN Bus
-@app.route("/can_bus")
+@app.route("/can_bus", methods=['GET', 'POST'])
 def can_bus():
     closed = dev_can_bus.closed
-    return render_template('can_bus.html', closed=closed)
+    if request.method == 'GET':
+        can_up = dev_can_bus.can_up
+        return render_template('can_bus.html', closed=closed, can_up=can_up)
+    if request.method == 'POST':
+        dev_can_bus.bring_up_can_device()
+        can_up = dev_can_bus.can_up
+        return render_template('can_bus.html', closed=closed, can_up=can_up)
 
 @socketio.on('can_send')
 def can_send(data):

--- a/models/can_bus.py
+++ b/models/can_bus.py
@@ -5,11 +5,10 @@ from lib.chipsee_board import board
 class CanBus(object):
     def __init__(self):
         self.can_dev_path = board.devices().get("can")
+        self.can_up = False
         if not self.can_dev_path:
-            self.can_up = False
             print("Cannot find CAN settings in board config. CAN bus not initialized.")
             return
-        self.bring_up_can_device()
         self.closed = True
         self.bus = None
             
@@ -21,6 +20,9 @@ class CanBus(object):
                 
     def bring_up_can_device(self):
         """
+        WARNING: Be sure to connect the 120 Ohm resistor before invoking this method, 
+        otherwise this program will freeze. 
+        
         If CAN bus device is not brought up from Linux, eg, with the "ip link up..." command,
         CAN device will not work.
         This method calls the Linux command for you to bring the CAN device up, if you do not

--- a/templates/can_bus.html
+++ b/templates/can_bus.html
@@ -11,6 +11,18 @@
 <body class="dark-bg sticky-body">
     {% include "common/navbar.html" %}
     <div class="container">
+        {% if not can_up %}
+        <form method="post" class="d-flex align-items-center justify-content-center" style="height: 90vh;">
+            <div>
+                <p class="text-white fw-bold text-center display-5">
+                    Warning: Be sure to connect the 120 Ohm resistor before bringing up the CAN device.
+                </p>
+                <input type="submit" name="bring_up_can_bus_button" value="OK, bring up CAN device"
+                    class="btn btn-success w-100 btn-lg fw-bold my-3">
+            </div>
+        </form>
+        {% endif %}
+        {% if can_up %}
         <form id="can_bus" class="mt-3">
             <div class="row mb-3">
                 <label for="can_bus_arbitration_id"
@@ -51,6 +63,7 @@
             </div>
         </div>
         <div id="log" class="can-log"></div>
+        {% endif %}
     </div>
 </body>
 


### PR DESCRIPTION
Because while testing CAN device with this program, CAN is brought up automatically while starting the program. But if the 120 Ohm resistor is not physically connected, the program will freeze. This change lets the user decide when to bring up the CAN device, and warn the user before they click on the enable CAN device button.